### PR TITLE
Add or condition to ticket emailer

### DIFF
--- a/src/emails/emails.ts
+++ b/src/emails/emails.ts
@@ -177,7 +177,11 @@ export async function ProcessTemplate(template: EmailTemplate): Promise<void> {
                         none: {
                             id: template.id
                         }
-                    }
+                    },
+                    OR: [
+                      { payment: null },
+                      { payment: { complete: true }},
+                    ],
                 },
                 ...extrafilters
             ]


### PR DESCRIPTION
Clear should only send emails to people who have finalized their payment (or are receiving a free ticket).